### PR TITLE
feat: move dialyzer to a separate github workflow

### DIFF
--- a/.github/workflows/dialyzer.yml
+++ b/.github/workflows/dialyzer.yml
@@ -1,0 +1,48 @@
+name: Dialyzer
+
+env:
+  ELIXIR_VERSION: "1.16.0"
+  OTP_VERSION: "26.2"
+  MIX_ENV: dev
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  dialyzer:
+    name: Dialyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+      - uses: actions/cache@v3
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-v2-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-mix-v2-
+      - uses: actions/cache@v3
+        with:
+          path: _build/test
+          key: ${{ runner.os }}-test-build
+          restore-keys: |
+            ${{ runner.os }}-test-build
+      - name: Install Dependencies
+        run: mix do deps.get, deps.compile
+      - name: Retrieve PLT Cache
+        uses: actions/cache@v3
+        id: plt-cache
+        with:
+          path: priv/plts
+          key: ${{ runner.os }}-dialyzer-plts-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+      - name: Create PLTs
+        if: steps.plt-cache.outputs.cache-hit != 'true'
+        run: |
+          mix dialyzer --plt
+      - name: Run dialyzer
+        run: mix dialyzer --no-check

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -43,5 +43,3 @@ jobs:
       run: mix credo --strict
     - name: Run Tests
       run: mix test
-    - name: Dialyzer
-      run: mix dialyzer

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ leaky-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+# Ignote dialyzer PLT files
+/priv/plts/*.plt
+/priv/plts/*.plt.hash

--- a/mix.exs
+++ b/mix.exs
@@ -10,12 +10,20 @@ defmodule Leaky.MixProject do
       source_url: "https://github.com/ihorkatkov/leaky",
       description: description(),
       package: package(),
+      dialyzer: dialyzer(),
       docs: [
         main: "Leaky",
         extras: ["README.md"]
       ],
       start_permanent: Mix.env() == :prod,
       deps: deps()
+    ]
+  end
+
+  defp dialyzer do
+    [
+      plt_core_path: "priv/plts",
+      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
     ]
   end
 


### PR DESCRIPTION
Closes #3 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Implemented a GitHub Actions workflow for Dialyzer to perform static analysis on the codebase.
  - Removed the Dialyzer step from the existing Elixir workflow.
  - Updated `.gitignore` to exclude Dialyzer PLT files.

- **New Features**
  - Configured Dialyzer settings in the project for improved type error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->